### PR TITLE
Fix double /api/ path in Server Actions

### DIFF
--- a/app/lib/utils/fetch.ts
+++ b/app/lib/utils/fetch.ts
@@ -36,13 +36,14 @@ export async function parseFetchResponse<T>(response: Response): Promise<T> {
 
 /**
  * Get API base URL
- * During build (SSG): Uses API_URL (full backend URL)
+ * During build (SSG): Uses API_URL (full backend URL with /api/ included)
  * During runtime: Uses NEXT_PUBLIC_API_URL (relative /api for same-domain)
  */
 export function getApiBaseUrl(): string {
     // Server-side during build: use full backend URL
+    // API_URL should already include /api/ (e.g., https://backend.com/api/)
     if (typeof window === 'undefined' && process.env.API_URL) {
-        return process.env.API_URL + '/api/';
+        return process.env.API_URL;
     }
     // Client-side or server-side runtime: use relative URL
     return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5296/api/';


### PR DESCRIPTION
- Remove duplicate /api/ concatenation in getApiBaseUrl()
- API_URL env var now expected to include /api/ suffix
- Fixes 404 errors on Railway deployment