### PR TITLE
Fix SignalR connection for Railway deployment

### DIFF
--- a/app/lib/hooks/useOrderHub.ts
+++ b/app/lib/hooks/useOrderHub.ts
@@ -2,8 +2,17 @@ import { useEffect, useState, useRef } from 'react';
 import * as signalR from '@microsoft/signalr';
 import { useNotificationStore } from '@/app/lib/store/notificationStore';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5296/api/';
-const HUB_URL = API_URL.replace('/api/', '/hubs/order');
+// In production (Railway), use relative URL to go through Next.js rewrites
+// In development, use absolute backend URL
+const getHubUrl = () => {
+  if (process.env.NODE_ENV === 'production') {
+    return '/hubs/order'; // Relative URL - will be rewritten by Next.js
+  }
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5296/api/';
+  return API_URL.replace('/api/', '/hubs/order'); // Absolute URL for development
+};
+
+const HUB_URL = getHubUrl();
 
 export const useOrderHub = () => {
   const [isConnected, setIsConnected] = useState(false);

--- a/next.config.ts
+++ b/next.config.ts
@@ -50,6 +50,10 @@ const nextConfig: NextConfig = {
           source: '/api/:path*',
           destination: `https://${process.env.BACKEND_INTERNAL_URL}/api/:path*`,
         },
+        {
+          source: '/hubs/:path*',
+          destination: `https://${process.env.BACKEND_INTERNAL_URL}/hubs/:path*`,
+        },
       ];
     }
 


### PR DESCRIPTION
- Add /hubs/* rewrite in next.config.ts to proxy SignalR requests
- Update useOrderHub to use relative URL in production
- Fixes 404 error on /hubs/order/negotiate endpoint